### PR TITLE
use devtools

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webdriverio-performance-testing",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A small showcase on how to test performance using WebdriverIO",
   "main": "wdio.conf.js",
   "scripts": {
@@ -36,8 +36,6 @@
     "@wdio/spec-reporter": "^6.1.12",
     "@wdio/sync": "^6.1.8",
     "chai": "^4.2.0",
-    "chromedriver": "^83.0.0",
-    "wdio-chromedriver-service": "^6.0.3",
     "webdriverio": "^6.1.12"
   }
 }

--- a/wdio.local.conf.js
+++ b/wdio.local.conf.js
@@ -19,7 +19,8 @@ exports.config = Object.assign(common, {
   // Services take over a specific job you don't want to take care of. They enhance
   // your test setup with almost no effort. Unlike plugins, they don't add new
   // commands. Instead, they hook themselves up into the test process.
-  services: ['devtools', 'chromedriver'],
+  services: ['devtools'],
+  automationProtocol: 'devtools',
   maxInstances: 2,
 
   // logs


### PR DESCRIPTION
I feel like we should use devtools for backend in this example repe, so we do not have a chromedriver dependency to keep track of.